### PR TITLE
Added Azure loadbalancers support

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -3,11 +3,6 @@
 {{ printf "%s-tbmq-node" .Release.Name }}
 {{- end }}
 
-{{/*Return a tbmq node host*/}}
-{{- define "tbmq.node.host" }}
-{{- printf "%s-tbmq-node" .Release.Name}}
-{{- end}}
-
 {{/*Return a tbmq node image*/}}
 {{- define "tbmq.node.image" -}}
 {{- $repository := .Values.tbmq.image.repository | default "thingsboard/tbmq-node" }}
@@ -31,7 +26,6 @@
 {{- $appversion := index .Values "tbmq-ie" "image" "tag" | default (printf "%s" .Chart.AppVersion) }}
 {{- printf "%s:%s" $repository $appversion }}
 {{- end }}
-
 
 {{/*Return redis cluster configurations environment variables for tbmq services*/}}
 {{- define "tbmq.redis.configuration.ref"}}
@@ -112,12 +106,10 @@
 {{- end }}
 {{- end }}
 
-
 {{/*Return tbmq image pull secret*/}}
 {{- define "tbmq.imagePullSecret" }}
 {{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.dockerAuth.registry (printf "%s:%s" .Values.dockerAuth.username .Values.dockerAuth.password | b64enc) | b64enc }}
 {{- end }}
-
 
 {{/*Init container that will slow deployment and let Service deploy after all scripts in the container exit successfully or timeout.*/}}
 {{- define "tbmq.initcontainers" }}

--- a/templates/loadbalancer/aws/mqtt-load-balancer.yml
+++ b/templates/loadbalancer/aws/mqtt-load-balancer.yml
@@ -1,20 +1,4 @@
-#
-# Copyright © 2016-2024 The Thingsboard Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
-{{- if .Values.awscontroller.mqtt.enabled }}
+{{- if and (eq .Values.loadbalancer.provider "aws") .Values.loadbalancer.mqtt.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -27,15 +11,15 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
     service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: stickiness.enabled=true,stickiness.type=source_ip
     service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: TBMQClusterELB=TBMQMqtt
-    {{- if and (not .Values.awscontroller.mqtt.mutualTls.enabled) .Values.awscontroller.mqtt.tlsTermination.enabled }}
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{ .Values.awscontroller.mqtt.tlsTermination.certificateARN }}
+    {{- if and (not .Values.loadbalancer.mqtt.mutualTls.enabled) .Values.loadbalancer.mqtt.tlsTermination.enabled }}
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{ .Values.loadbalancer.mqtt.tlsTermination.certificateRef }}
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "tcp"
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "mqtts,mqtt-wss"
     {{- end }}
 spec:
   type: LoadBalancer
   selector:
-    app: {{ include "tbmq.node.host" . }}
+    app: {{ include "tbmq.node.label" . }}
   ports:
     - name: mqtt
       port: 1883
@@ -43,7 +27,7 @@ spec:
     - name: mqtt-ws
       port: 8084
       targetPort: 8084
-    {{- if and (not .Values.awscontroller.mqtt.mutualTls.enabled) .Values.awscontroller.mqtt.tlsTermination.enabled }}
+    {{- if and (not .Values.loadbalancer.mqtt.mutualTls.enabled) .Values.loadbalancer.mqtt.tlsTermination.enabled }}
     # This way NLB acts as an TLS termination point and forwards decrypted traffic to 1883 port of the TBMQ.
     - name: mqtts
       port: 8883

--- a/templates/loadbalancer/azure/http-load-balancer.yml
+++ b/templates/loadbalancer/azure/http-load-balancer.yml
@@ -1,17 +1,16 @@
-{{- if and (eq .Values.loadbalancer.provider "aws") .Values.loadbalancer.http.enabled }}
+{{- if and (eq .Values.loadbalancer.provider "azure") .Values.loadbalancer.http.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-http-lb
   namespace: {{ .Release.Namespace }}
   annotations:
-    kubernetes.io/ingress.class: alb
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/target-type: ip
+    appgw.ingress.kubernetes.io/use-regex: 'true'
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/request-timeout: "300"
     {{- if .Values.loadbalancer.http.ssl.enabled }}
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.loadbalancer.http.ssl.certificateRef }}
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/ssl-redirect: '443'
+    appgw.ingress.kubernetes.io/appgw-ssl-certificate: {{ .Values.loadbalancer.http.ssl.certificateRef }}
+    appgw.ingress.kubernetes.io/ssl-redirect: "true"
     {{- end }}
 spec:
   rules:

--- a/templates/loadbalancer/azure/mqtt-load-balancer.yml
+++ b/templates/loadbalancer/azure/mqtt-load-balancer.yml
@@ -1,0 +1,26 @@
+{{- if and (eq .Values.loadbalancer.provider "azure") .Values.loadbalancer.mqtt.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-mqtt-lb
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-internal: "false"
+spec:
+  type: LoadBalancer
+  selector:
+    app: {{ include "tbmq.node.label" . }}
+  ports:
+    - name: mqtt
+      port: 1883
+      targetPort: 1883
+    - name: mqtt-ws
+      port: 8084
+      targetPort: 8084
+    - name: mqtts
+      port: 8883
+      targetPort: 8883
+    - name: mqtt-wss
+      port: 8085
+      targetPort: 8085
+{{- end }}

--- a/templates/tbmq/tbmq-default-mqtts-config.yml
+++ b/templates/tbmq/tbmq-default-mqtts-config.yml
@@ -1,4 +1,4 @@
-{{- if and .Values.awscontroller.mqtt.mutualTls.enabled (empty .Values.awscontroller.mqtt.mutualTls.existingConfigMap) }}
+{{- if and .Values.loadbalancer.mqtt.mutualTls.enabled (empty .Values.loadbalancer.mqtt.mutualTls.existingConfigMap) }}
 {{- $namespace := .Release.Namespace -}}
 {{- $releaseName := .Release.Name }}
 apiVersion: v1
@@ -10,7 +10,7 @@ metadata:
     name: {{ printf "%s-tbmq-node-default-mqtts-config" $releaseName }}
 data:
   server.pem: |-
-    {{- .Files.Get .Values.awscontroller.mqtt.mutualTls.serverCertificate | nindent 4 }}
+    {{- .Files.Get .Values.loadbalancer.mqtt.mutualTls.serverCertificate | nindent 4 }}
   mqttserver_key.pem: |-
-    {{- .Files.Get .Values.awscontroller.mqtt.mutualTls.privateKey | nindent 4 }}
+    {{- .Files.Get .Values.loadbalancer.mqtt.mutualTls.privateKey | nindent 4 }}
 {{- end }}

--- a/templates/tbmq/tbmq-statefulset.yml
+++ b/templates/tbmq/tbmq-statefulset.yml
@@ -63,7 +63,7 @@ spec:
               value: "false"
             - name: HTTP_LOG_CONTROLLER_ERROR_STACK_TRACE
               value: "false"
-            {{- if .Values.awscontroller.mqtt.mutualTls.enabled }}
+            {{- if .Values.loadbalancer.mqtt.mutualTls.enabled }}
             - name: LISTENER_SSL_ENABLED
               value: "true"
             - name: LISTENER_SSL_CREDENTIALS_TYPE
@@ -92,7 +92,7 @@ spec:
             - name: {{ printf "%s-tbmq-node-logback-config" $releaseName }}
               mountPath: /config/logback.xml
               subPath: logback.xml
-            {{- if .Values.awscontroller.mqtt.mutualTls.enabled }}
+            {{- if .Values.loadbalancer.mqtt.mutualTls.enabled }}
             - name: {{ printf "%s-tbmq-node-mqtts-config" $releaseName }}
               mountPath: /ssl-config
             {{- end }}
@@ -115,10 +115,10 @@ spec:
             items:
               - key: logback
                 path: logback.xml
-        {{- if .Values.awscontroller.mqtt.mutualTls.enabled }}
+        {{- if .Values.loadbalancer.mqtt.mutualTls.enabled }}
         - name: {{ printf "%s-tbmq-node-mqtts-config" $releaseName }}
           configMap:
-            name: {{ ternary (printf "%s-tbmq-node-default-mqtts-config" $releaseName) .Values.awscontroller.mqtt.mutualTls.existingConfigMap  (empty .Values.awscontroller.mqtt.mutualTls.existingConfigMap) }}
+            name: {{ ternary (printf "%s-tbmq-node-default-mqtts-config" $releaseName) .Values.loadbalancer.mqtt.mutualTls.existingConfigMap  (empty .Values.loadbalancer.mqtt.mutualTls.existingConfigMap) }}
             items:
               - key: server.pem
                 path: server.pem

--- a/values.yaml
+++ b/values.yaml
@@ -630,29 +630,36 @@ kafka:
       ##
       resources: { }
 
-# AWS Load Balancer Controller Configuration
-# This section configures AWS-specific load balancers for TBMQ.
-# It includes support for:
-# - **Application Load Balancer (ALB)** for HTTP/HTTPS traffic.
-# - **Network Load Balancer (NLB)** for MQTT traffic.
-#
-# If you are using AWS controller, enable the relevant sections below.
-awscontroller:
-  # HTTP(S) Load Balancer (ALB)
+# Load Balancer Configuration
+# This section defines the load balancer settings for TBMQ.
+# Supported providers:
+# - AWS: Uses Application Load Balancer (ALB) for HTTP(S) traffic and Network Load Balancer (NLB) for MQTT traffic.
+# - Azure: Uses Application Gateway for HTTP(S) traffic and Azure Load Balancer for MQTT traffic.
+loadbalancer:
+  # Cloud provider for the load balancer. Supported values: "aws", "azure"
+  provider: "aws"
+  # HTTP(S) Load Balancer Configuration (Application Layer - L7)
+  # This load balancer is used for HTTP/HTTPS traffic, such as REST APIs.
   http:
+    # Set to true to enable the HTTP load balancer.
     enabled: false
     ssl:
-      # Set to true to enable HTTPS (requires ACM Certificate)
+      # Enables HTTPS termination at the load balancer level.
       enabled: false
-      # AWS ACM certificate ARN for HTTPS
-      certificateARN: ""
-  # MQTT Load Balancer (NLB)
+      # Certificate reference:
+      # - AWS: The ACM certificate ARN for ALB.
+      # - Azure: The `appgw-ssl-certificate` value in Application Gateway.
+      certificateRef: ""
+  # MQTT Load Balancer Configuration (Transport Layer - L4)
+  # This load balancer is used for MQTT traffic (TCP).
   mqtt:
+    # Set to true to enable the MQTT load balancer.
     enabled: false
-    # Two-Way TLS (Mutual TLS on the TBMQ service side)
+    # Two-Way TLS (Mutual TLS or mTLS) - Handled at the TBMQ application level.
+    # This ensures that both the client and the server authenticate each other.
     mutualTls:
-      # Set to true to enable two-way TLS (mutual authentication). If enabled, tlsTermination option will be ignored.
-      # Requires server certificate and private key.
+      # Set to true to enable mutual TLS (mTLS) authentication. Requires server certificate and private key.
+      # TLS Termination (see below) will be ignored if this is enabled.
       enabled: false
       # Optional: Use an existing ConfigMap instead of creating one.
       # If specified, the ConfigMap must contain the following keys:
@@ -680,9 +687,14 @@ awscontroller:
       serverCertificate: ""
       # Path to mqttserver_key.pem file (required only if @param existingConfigMap is empty)
       privateKey: ""
-    # One-Way TLS (TLS Termination on load balancer side)
+    # One-Way TLS Termination (Handled at Load Balancer Level - L4)
+    # This option allows the load balancer to terminate TLS and pass decrypted traffic to TBMQ.
+    # - AWS: TLS termination is supported via Network Load Balancer (NLB) with an ACM certificate.
+    # - Azure: TLS termination is NOT supported at the Azure Load Balancer level.
     tlsTermination:
-      # Set to true to enable one-way TLS (requires ACM Certificate). Will be ignored if @param mutualTls.enabled is set to true
+      # Set to true to enable TLS termination at the load balancer. Will be ignored if @param mutualTls.enabled is set to true
       enabled: false
-      # AWS ACM certificate ARN for TLS Termination
-      certificateARN: ""
+      # Certificate reference for TLS termination:
+      # - AWS: The ACM certificate ARN for NLB.
+      # - Azure: Not applicable (this option will be ignored).
+      certificateRef: ""


### PR DESCRIPTION
This PR extends the Load Balancer Configuration in the TBMQ Helm Chart by introducing support for Azure Load Balancer while maintaining the existing AWS-specific configuration. The goal is to unify the load balancer settings for multi-cloud deployments.

## Key Changes:

**1. Refactored Load Balancer Configuration:**

- Replaced awscontroller with a more generic loadbalancer configuration block.
- Introduced a provider field to specify the cloud provider:

```
loadbalancer:
  provider: "aws" # Supported values: "aws", "azure"
```

This allows seamless switching between AWS and Azure load balancers.

**2. AWS Load Balancer Configuration (No Breaking Changes)** 

 - The previous awscontroller configuration remains functionally the same, just moved under loadbalancer.
 - ALB (Application Load Balancer) remains for HTTP/HTTPS traffic.
 - NLB (Network Load Balancer) remains for MQTT traffic.

**3. Added Azure Load Balancer Support:**

 - Introduced support for Azure Load Balancer for MQTT (TCP) traffic.
 - Azure Application Gateway is used for HTTP/HTTPS traffic. 
