### PR TITLE
Add GCP Load Balancer Support + Minor Improvements

### DIFF
--- a/templates/loadbalancer/aws/mqtt-load-balancer.yml
+++ b/templates/loadbalancer/aws/mqtt-load-balancer.yml
@@ -18,6 +18,7 @@ metadata:
     {{- end }}
 spec:
   type: LoadBalancer
+  externalTrafficPolicy: Local
   selector:
     app: {{ include "tbmq.node.label" . }}
   ports:

--- a/templates/loadbalancer/gcp/http-load-balancer.yml
+++ b/templates/loadbalancer/gcp/http-load-balancer.yml
@@ -1,0 +1,45 @@
+{{- if and (eq .Values.loadbalancer.provider "gcp") .Values.loadbalancer.http.enabled }}
+{{- if .Values.loadbalancer.http.ssl.enabled }}
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: {{ .Values.loadbalancer.http.ssl.certificateRef }}
+spec:
+  domains:
+    {{-  range $domain := .Values.loadbalancer.http.ssl.domains }}
+    - {{ $domain }}
+    {{- end }}
+---
+apiVersion: networking.gke.io/v1beta1
+kind: FrontendConfig
+metadata:
+  name: tbmq-http-fe-config
+spec:
+  redirectToHttps:
+    enabled: true
+---
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-http-lb
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/ingress.class: "gce"
+    {{- if .Values.loadbalancer.http.ssl.enabled }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.loadbalancer.http.ssl.staticIP }}
+    networking.gke.io/managed-certificates: {{ .Values.loadbalancer.http.ssl.certificateRef }}
+    networking.gke.io/v1beta1.FrontendConfig: tbmq-http-fe-config
+    {{- end }}
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ include "tbmq.node.label" . }}
+                port:
+                  name: http
+{{- end }}

--- a/templates/loadbalancer/gcp/mqtt-load-balancer.yml
+++ b/templates/loadbalancer/gcp/mqtt-load-balancer.yml
@@ -1,11 +1,9 @@
-{{- if and (eq .Values.loadbalancer.provider "azure") .Values.loadbalancer.mqtt.enabled }}
+{{- if and (eq .Values.loadbalancer.provider "gcp") .Values.loadbalancer.mqtt.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-mqtt-lb
   namespace: {{ .Release.Namespace }}
-  annotations:
-    service.beta.kubernetes.io/azure-load-balancer-internal: "false"
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local

--- a/templates/tbmq/tbmq-statefulset.yml
+++ b/templates/tbmq/tbmq-statefulset.yml
@@ -20,7 +20,6 @@ spec:
       annotations:
         {{- if .Values.tbmq.enableChecksumAnnotations }}
         checksum/config: {{ include (print $.Template.BasePath "/tbmq/tbmq-default-configmap.yml") . | sha256sum }}
-        checksum/logging: {{ include (print $.Template.BasePath "/tbmq/tbmq-default-logback-configmap.yml") . | sha256sum }}
         checksum/env: {{ include (print $.Template.BasePath "/tbmq/tbmq-custom-env.yml") . | sha256sum }}
         checksum/mqtts: {{ include (print $.Template.BasePath "/tbmq/tbmq-default-mqtts-config.yml") . | sha256sum }}
         checksum/postgres-config: {{ include (print $.Template.BasePath "/postgres/postgres-configmap.yml") . | sha256sum }}

--- a/values.yaml
+++ b/values.yaml
@@ -635,8 +635,9 @@ kafka:
 # Supported providers:
 # - AWS: Uses Application Load Balancer (ALB) for HTTP(S) traffic and Network Load Balancer (NLB) for MQTT traffic.
 # - Azure: Uses Application Gateway for HTTP(S) traffic and Azure Load Balancer for MQTT traffic.
+# - GCP: Uses HTTPS Load Balancer for HTTP(S) traffic and Network Load Balancer (NLB) for MQTT traffic.
 loadbalancer:
-  # Cloud provider for the load balancer. Supported values: "aws", "azure"
+  # Cloud provider for the load balancer. Supported values: "aws", "azure", "gcp"
   provider: "aws"
   # HTTP(S) Load Balancer Configuration (Application Layer - L7)
   # This load balancer is used for HTTP/HTTPS traffic, such as REST APIs.
@@ -649,7 +650,17 @@ loadbalancer:
       # Certificate reference:
       # - AWS: The ACM certificate ARN for ALB.
       # - Azure: The `appgw-ssl-certificate` value in Application Gateway.
+      # - GCP: The name of the ManagedCertificate resource
       certificateRef: ""
+      # List of domains for HTTPS traffic.
+      # - AWS: Not used in Ingress. Domains are part of the ACM certificate specified in `certificateRef`.
+      # - Azure: Not used in Ingress. Domains are managed directly in Application Gateway.
+      # - GCP: Required in Ingress. Domains must be listed for GCP ManagedCertificate to issue an SSL certificate.
+      domains:
+        - www.example.com
+      # Static IP address for the GCP HTTP(S) load balancer.
+      # Required for GCP. Ignored for AWS/Azure.
+      staticIP: "tbmq-http-lb-address"
   # MQTT Load Balancer Configuration (Transport Layer - L4)
   # This load balancer is used for MQTT traffic (TCP).
   mqtt:
@@ -691,10 +702,12 @@ loadbalancer:
     # This option allows the load balancer to terminate TLS and pass decrypted traffic to TBMQ.
     # - AWS: TLS termination is supported via Network Load Balancer (NLB) with an ACM certificate.
     # - Azure: TLS termination is NOT supported at the Azure Load Balancer level.
+    # - GCP: TLS termination is NOT supported at the GCP Network Load Balancer level.
     tlsTermination:
       # Set to true to enable TLS termination at the load balancer. Will be ignored if @param mutualTls.enabled is set to true
       enabled: false
       # Certificate reference for TLS termination:
       # - AWS: The ACM certificate ARN for NLB.
       # - Azure: Not applicable (this option will be ignored).
+      # - GCP: Not applicable (this option will be ignored).
       certificateRef: ""


### PR DESCRIPTION
**Add GCP Load Balancer Support to TBMQ Helm Chart**

This PR extends the Load Balancer Configuration in the TBMQ Helm Chart by introducing Google Cloud Platform (GCP) Load Balancer support, while maintaining existing AWS and Azure configurations. This enhances multi-cloud deployment capabilities for TBMQ.

```
loadbalancer:
  provider: "aws" # Supported values: "aws", "azure", "gcp"
```

**GCP HTTPS Load Balancer (L7)**
 - Supports HTTP and HTTPS traffic.
 - Uses GCP ManagedCertificate for SSL termination.
 - Requires a static global IP for stability.

**GCP Network Load Balancer (L4)**

 - Used for MQTT traffic (TCP).
 - Does not support TLS termination (TBMQ must handle TLS internally).