### PR TITLE
refactor(tbmq): drop dead Jedis cluster topology-refresh keys from Redis ConfigMap

### DIFF
--- a/tbmq/Chart.yaml
+++ b/tbmq/Chart.yaml
@@ -14,6 +14,8 @@ annotations:
       email: dlandiak@thingsboard.io
   artifacthub.io/prerelease: "false"
   artifacthub.io/changes: |
+    - kind: removed
+      description: "Removed the dead REDIS_JEDIS_CLUSTER_TOPOLOGY_REFRESH_ENABLED / REDIS_JEDIS_CLUSTER_TOPOLOGY_REFRESH_PERIOD_SEC keys from the Redis cluster ConfigMap. TBMQ no longer ships the custom Jedis cluster topology refresher — Jedis rediscovers cluster topology reactively (renewSlotCache on MOVED redirects and connection failures), so the broker ignored these keys. The Lettuce topology-refresh tunables are unchanged."
     - kind: fixed
       description: "tbmq-ie StatefulSet no longer hardcodes TB_SERVICE_INTEGRATIONS_SUPPORTED=ALL and TB_SERVICE_INTEGRATIONS_EXCLUDED=NONE as container env: entries. Container env: takes precedence over envFrom: in Kubernetes, so the previous hardcoding silently shadowed any user override via tbmq-ie.customEnv — contradicting the chart's documented \"customEnv always wins\" override hierarchy. Application defaults (ALL, NONE) are preserved; users can now tune both vars via tbmq-ie.customEnv."
     - kind: fixed

--- a/tbmq/README.md
+++ b/tbmq/README.md
@@ -708,7 +708,7 @@ redis:
 ```
 
 In `cluster` mode, the chart automatically renders cluster-only keys (`REDIS_NODES`,
-`REDIS_MAX_REDIRECTS`, `REDIS_CLUSTER_USE_DEFAULT_POOL_CONFIG`, and the Lettuce/Jedis topology
+`REDIS_MAX_REDIRECTS`, `REDIS_CLUSTER_USE_DEFAULT_POOL_CONFIG`, and the Lettuce topology
 refresh tunables) into the Redis ConfigMap; in `standalone` mode those keys are omitted and only
 `REDIS_HOST`/`REDIS_PORT` are set.
 

--- a/tbmq/templates/redis/redis-configmap.yaml
+++ b/tbmq/templates/redis/redis-configmap.yaml
@@ -50,10 +50,4 @@ data:
   REDIS_LETTUCE_CLUSTER_TOPOLOGY_REFRESH_ENABLED: "true"
   # Specifies the interval (in seconds) for periodic cluster topology updates
   REDIS_LETTUCE_CLUSTER_TOPOLOGY_REFRESH_PERIOD_SEC: "60"
-  # Enables or disables periodic cluster topology updates.
-  # Useful for Redis cluster setup to handle topology changes,
-  # such as node failover, restarts, or IP address changes
-  REDIS_JEDIS_CLUSTER_TOPOLOGY_REFRESH_ENABLED: "true"
-  # Specifies the interval (in seconds) for periodic cluster topology updates
-  REDIS_JEDIS_CLUSTER_TOPOLOGY_REFRESH_PERIOD_SEC: "60"
   {{- end }}


### PR DESCRIPTION
Removes the now-dead `REDIS_JEDIS_CLUSTER_TOPOLOGY_REFRESH_ENABLED` / `REDIS_JEDIS_CLUSTER_TOPOLOGY_REFRESH_PERIOD_SEC` keys from the TBMQ Redis cluster ConfigMap (`tbmq/templates/redis/redis-configmap.yaml`) and the matching README mention.

TBMQ removed the custom `JedisClusterTopologyRefresher` (CE PR thingsboard/tbmq#334): it was a no-op, and Jedis already rediscovers cluster topology reactively (`renewSlotCache` on `MOVED` redirects and connection failures). The broker now ignores these env vars, so the chart should stop setting them. Lettuce topology-refresh tunables are unchanged.

- helm lint: pass
- `helm template --set redis.connectionType=cluster`: ConfigMap renders with only the Lettuce keys
- Added an `artifacthub.io/changes` entry (kind: removed); chart `version` left for the release step.